### PR TITLE
feat: add simplest n8n docker compose

### DIFF
--- a/composes/n8n/.env
+++ b/composes/n8n/.env
@@ -1,0 +1,8 @@
+# shellcheck disable=SC2034
+POSTGRES_USER=root
+POSTGRES_PASSWORD=password
+POSTGRES_DB=n8n
+
+N8N_ENCRYPTION_KEY=super-secret-key
+N8N_USER_MANAGEMENT_JWT_SECRET=even-more-secret
+N8N_DEFAULT_BINARY_DATA_MODE=filesystem

--- a/composes/n8n/compose.yml
+++ b/composes/n8n/compose.yml
@@ -1,0 +1,59 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    hostname: postgres
+    networks:
+      - n8n
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DB
+    volumes:
+      - postgres_storage:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -h localhost -U ${POSTGRES_USER} -d ${POSTGRES_DB}",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  n8n:
+    image: n8nio/n8n:1.90.2
+    hostname: n8n
+    container_name: n8n
+    restart: unless-stopped
+    ports:
+      - 5678:5678
+    volumes:
+      - n8n_storage:/home/node/.n8n
+    environment:
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_HOST=postgres
+      - DB_POSTGRESDB_USER=${POSTGRES_USER}
+      - DB_POSTGRESDB_PASSWORD=${POSTGRES_PASSWORD}
+      - N8N_DIAGNOSTICS_ENABLED=false
+      - N8N_PERSONALIZATION_ENABLED=false
+      - N8N_ENCRYPTION_KEY
+      - N8N_USER_MANAGEMENT_JWT_SECRET
+      - OLLAMA_HOST=ollama:11434
+    env_file:
+      - .env
+    networks:
+      - n8n
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  n8n_storage:
+  postgres_storage:
+
+networks:
+  n8n:
+    driver: bridge


### PR DESCRIPTION
## Pull Request: Docker Compose Setup for n8n

This pull request introduces a Docker Compose setup for the n8n workflow automation tool. This allows for easier local development and deployment of n8n.

**Files Changed:**

- **`/composes/n8n/.env` (New File):** This file contains environment variables for configuring the n8n instance and the PostgreSQL database. It includes settings for the database user, password, and name, as well as encryption keys for n8n. These are placeholder values and should be replaced with secure values in production environments.

```
# shellcheck disable=SC2034
POSTGRES_USER=root
POSTGRES_PASSWORD=password
POSTGRES_DB=n8n

N8N_ENCRYPTION_KEY=super-secret-key
N8N_USER_MANAGEMENT_JWT_SECRET=even-more-secret
N8N_DEFAULT_BINARY_DATA_MODE=filesystem
```

- **`/composes/n8n/compose.yml` (New File):** This file defines the Docker Compose configuration. It sets up a PostgreSQL database and an n8n instance, linking them together. The configuration includes health checks for the database, volume mounts for persistent storage, and environment variable handling.

```yaml
version: "3.8"

services:
  postgres:
    image: postgres:16-alpine
    # ... (rest of the postgres configuration) ...
  n8n:
    image: n8nio/n8n:1.90.2
    # ... (rest of the n8n configuration) ...

volumes:
  n8n_storage:
  postgres_storage:

networks:
  n8n:
    driver: bridge
```

**Reason for Changes:**

This change simplifies the process of setting up and running n8n locally. Using Docker Compose allows for consistent environment management across different development machines and eliminates the need for manual database setup and configuration.

**Impact of Changes:**

This change introduces a new dependency (Docker and Docker Compose) for local development. However, it simplifies the setup significantly, making it easier for developers to contribute to the project and for users to get started with n8n. The use of volumes ensures that data persists even if the containers are restarted. The use of environment variables allows for easier configuration management.

**Test Plan:**

1. Ensure Docker and Docker Compose are installed.
2. Navigate to the `composes/n8n` directory.
3. Run `docker-compose up -d`.
4. Verify that the n8n instance is accessible at `http://localhost:5678`.
5. Test basic n8n functionality (creating a workflow, running a node).
6. Stop and remove the containers using `docker-compose down`.

**Additional Notes:**

- The environment variables in `.env` are placeholders and **must** be changed to secure values before deploying to a production environment.
- The `OLLAMA_HOST` variable suggests integration with an LLM. This should be documented and adjusted based on the actual setup.
- Consider adding a `.dockerignore` file to exclude unnecessary files from the Docker image.
- This setup assumes an `ollama` service is available on port 11434. This should be verified and the port adjusted if necessary.

Potential Bugs:

- **Environment Variable Conflicts:** If the environment variables defined in `.env` conflict with existing environment variables on the system, it could cause unexpected behavior. Thorough testing with different environments is crucial.
- **Database Connection Issues:** Incorrect database credentials or network problems could prevent the n8n instance from connecting to the database. The health checks implemented should mitigate this, but it needs to be verified.
- **Port Conflicts:** The port 5678 might be in use by another application. The compose file should be adjusted if this happens.
